### PR TITLE
Make the base image compatible with matplotlib

### DIFF
--- a/docker-builds/base/Dockerfile
+++ b/docker-builds/base/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get install -y -q curl
 RUN apt-get install -y -q sudo
 RUN apt-get install -y -q python-dev
 RUN apt-get install -y -q python-pip
+RUN apt-get install -y -q python-matplotlib
 
 # gcc and make should be available from python-dev
 # RUN apt-get install -y -q gcc

--- a/docker-builds/base/supervisor/ipynotebook.conf
+++ b/docker-builds/base/supervisor/ipynotebook.conf
@@ -1,7 +1,7 @@
 [program:notebook]
 directory = /home/user/ipynotebooks/
 user = user
-environment = IPYTHONDIR=/home/user/ipython-conf
+environment = IPYTHONDIR=/home/user/ipython-conf, MPLCONFIGDIR=/home/user/
 command = ipython notebook --profile=nbserver
 autostart = true
 autorestart = false

--- a/docker-builds/base/supervisor/ipynotebook.conf
+++ b/docker-builds/base/supervisor/ipynotebook.conf
@@ -2,7 +2,7 @@
 directory = /home/user/ipynotebooks/
 user = user
 environment = IPYTHONDIR=/home/user/ipython-conf, MPLCONFIGDIR=/home/user/
-command = ipython notebook --profile=nbserver
+command = ipython notebook --pylab inline --profile=nbserver
 autostart = true
 autorestart = false
 redirect_stderr = true


### PR DESCRIPTION
The MPLCONFIGDIR by default is '/', which is not writable by the user 'user'. By adding this line, it will work (it took me some time to find this out, especially because the error handling through layers of docker-containers-notebooks-web is not straightforward).

I tested it by manually installing matplotlib inside the container, 'docker commit' the change, and run jiffylabs from this new image.

I'm not sure whether the purpose of the base container 'ptone/jiffylab-base2' is to become more complete, but since matplotlib is a fairly basic thing to want to have, I added it here.
