### PR TITLE
Update .gitignore file to ignore compiled files and IntelliJ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 containers.json
 .vagrant/**
 .idea
+*.py[oc]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 containers.json
 .vagrant/**
+.idea


### PR DESCRIPTION
Updates `.gitignore` to ignore IntelliJ files (mostly for PyCharm) and any compiled `.pyc` or `.pyo`(Python 3) files.
